### PR TITLE
Use supplied name for accessory and fix return value for getOn

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(homebridge) {
 
 
 function TvAccessory(log, config) {
-    this.service = new Service.Switch('TV');
+    this.service = new Service.Switch(config["name"]);
     this.service
         .getCharacteristic(Characteristic.On)
         .on('get', this.getOn.bind(this))
@@ -24,16 +24,17 @@ function TvAccessory(log, config) {
 }
 
 TvAccessory.prototype.getOn = function(callback) {
-    var state = (devices[0].status == 1 ? 'on' : 'off');
+    var state = (devices[0].status == 1 ? true : false);
     callback(null, state);
 }
 
 TvAccessory.prototype.setOn = function(on, callback) {
-    if (devices[0].status == 0) {
+    if (devices[0].status == 0 && on) {
         console.log('Turning TV on');
         cec.send('on 0');
         devices[0].status = 1;
-    } else {
+    }
+    if (devices[0].status == 1 && !on) {
         console.log('Turning TV off');
         cec.send('standby 0');
         devices[0].status = 0;
@@ -58,7 +59,7 @@ TvAccessory.prototype.getServices = function() {
 
 
 function AmpAccessory(log, config) {
-    this.service = new Service.Switch('AMP');
+    this.service = new Service.Switch(config["name"]);
     this.service
         .getCharacteristic(Characteristic.On)
         .on('get', this.getOn.bind(this))
@@ -66,16 +67,17 @@ function AmpAccessory(log, config) {
 }
 
 AmpAccessory.prototype.getOn = function(callback) {
-    var state = (devices[5].status == 1 ? 'on' : 'off');
+    var state = (devices[5].status == 1 ? true : false);
     callback(null, state);
 }
 
 AmpAccessory.prototype.setOn = function(on, callback) {
-    if (devices[5].status == 0) {
+    if (devices[5].status == 0 && on) {
         console.log('Turning AMP on');
         cec.send('on 5');
         devices[5].status = 1;
-    } else {
+    }
+    if (devices[5].status == 1 && !on) {
         console.log('Turning AMP off');
         cec.send('standby 5');
         devices[5].status = 0;


### PR DESCRIPTION
I have made some small changes to fix the wrong return value for the getOn method. Without this fix the iOS10 Home application wasn't able to retrieve the current state of the device.
Then I changed the setOn method to evaluate the desired state before triggering the tv. This should be more safely.

Also I think it is better to use the supplied name from the user configuration for the accessory display name to give the user the choice about the names.
